### PR TITLE
Don't add array-compare and infinite-recursion on MinGW yet

### DIFF
--- a/src/modules/target_common_warnings.cmake
+++ b/src/modules/target_common_warnings.cmake
@@ -38,8 +38,12 @@ function(target_common_warnings TARGET SCOPE)
   # Make some errors
   set(C_ERRORS "$<$<COMPILE_LANGUAGE:C>:-Werror-implicit-function-declaration>")
   set(C_CXX_ERRORS
-      -Werror=array-bounds;-Werror=array-compare;-Werror=dangling-else;-Werror=implicit-fallthrough;-Werror=parentheses;-Werror=infinite-recursion;-Werror=logical-not-parentheses;-Werror=misleading-indentation;-Werror=return-type;-Werror=sequence-point;-Werror=shift-negative-value;-Werror=shift-overflow;-Werror=sizeof-array-div;-Werror=strict-aliasing;-Werror=tautological-compare;-Werror=type-limits
+      -Werror=array-bounds;-Werror=dangling-else;-Werror=implicit-fallthrough;-Werror=parentheses;-Werror=logical-not-parentheses;-Werror=misleading-indentation;-Werror=return-type;-Werror=sequence-point;-Werror=shift-negative-value;-Werror=shift-overflow;-Werror=sizeof-array-div;-Werror=strict-aliasing;-Werror=tautological-compare;-Werror=type-limits
   )
+
+  if(NOT MINGW)
+    list(APPEND C_CXX_ERRORS -Werror=array-compare;-Werror=infinite-recursion)
+  endif()
 
   target_compile_options(
     ${TARGET}


### PR DESCRIPTION
Be nice to colleagues and disable some -Werror flags not yet available on MinGW 11.2