### PR TITLE
Sanitize

### DIFF
--- a/cmake/sanitize.cmake
+++ b/cmake/sanitize.cmake
@@ -22,20 +22,11 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ]]
 
-macro(sanitize SANITIZERS)
-  get_directory_property(HAS_PARENT_SCOPE PARENT_DIRECTORY)
-  if(HAS_PARENT_SCOPE)
-    set(CMAKE_C_FLAGS
-        "${CMAKE_C_FLAGS} -fsanitize=${SANITIZERS}"
-        PARENT_SCOPE)
-    set(CMAKE_CXX_FLAGS
-        "${CMAKE_CXX_FLAGS} -fsanitize=${SANITIZERS}"
-        PARENT_SCOPE)
-    set(LDFLAGS
-        "${LDFLAGS} -fsanitize=${SANITIZERS}"
-        PARENT_SCOPE)
-  endif()
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fsanitize=${SANITIZERS}")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=${SANITIZERS}")
-  set(LDFLAGS "${LDFLAGS} -fsanitize=${SANITIZERS}")
-endmacro()
+function(sanitize SANITIZERS)
+  set(CMAKE_C_FLAGS
+      "${CMAKE_C_FLAGS} -fsanitize=${SANITIZERS}"
+      CACHE STRING "Append -fsanitize=${SANITIZERS} to CMAKE_C_FLAGS" FORCE)
+  set(CMAKE_CXX_FLAGS
+      "${CMAKE_CXX_FLAGS} -fsanitize=${SANITIZERS}"
+      CACHE STRING "Append -fsanitize=${SANITIZERS} to CMAKE_CXX_FLAGS" FORCE)
+endfunction()

--- a/cmake/sanitize.cmake
+++ b/cmake/sanitize.cmake
@@ -23,10 +23,13 @@ SOFTWARE.
 ]]
 
 function(sanitize SANITIZERS)
+  cmake_policy(PUSH)
+  cmake_policy(SET CMP0126 OLD)
   set(CMAKE_C_FLAGS
       "${CMAKE_C_FLAGS} -fsanitize=${SANITIZERS}"
       CACHE STRING "Append -fsanitize=${SANITIZERS} to CMAKE_C_FLAGS" FORCE)
   set(CMAKE_CXX_FLAGS
       "${CMAKE_CXX_FLAGS} -fsanitize=${SANITIZERS}"
       CACHE STRING "Append -fsanitize=${SANITIZERS} to CMAKE_CXX_FLAGS" FORCE)
+  cmake_policy(POP)
 endfunction()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,3 +1,4 @@
 include(cpm.cmake)
 include(get_cqtdeployer.cmake)
 include(minify_html.cmake)
+include(sanitize.cmake)

--- a/tests/sanitize.cmake
+++ b/tests/sanitize.cmake
@@ -1,0 +1,6 @@
+sanitize(address,undefined)
+
+string(FIND ${CMAKE_C_FLAGS} "-fsanitize=address,undefined" fsanitize_POS)
+if(fsanitize_POS EQUAL -1)
+  message(FATAL_ERROR "CMAKE_C_FLAGS does not contain -fsanitize")
+endif()


### PR DESCRIPTION
sanitize function now sets `CMAKE_C_FLAGS` and `CMAKE_CXX_FLAGS` as CACHE variables, therefor making them visible in all scopes.