### PR TITLE
fix: add_clang_format_target doesn't fail without clang-format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.9.3
+- Update to CPM 0.40.2
+- Bugfix `add_clang_format_target` doesn't fail without `clang-format`
+
 ## 0.9.2
 - Update to CPM 0.40.1
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ if(NOT cpm.cmake_SOURCE_DIR)
   FetchContent_Declare(
     CPM.cmake
     GIT_REPOSITORY "https://github.com/cpm-cmake/CPM.cmake.git"
-    GIT_TAG v0.40.1)
+    GIT_TAG v0.40.2)
   FetchContent_MakeAvailable(CPM.cmake)
   include(${cpm.cmake_SOURCE_DIR}/cmake/CPM.cmake)
 endif()

--- a/cmake/add_clang_format_target.cmake
+++ b/cmake/add_clang_format_target.cmake
@@ -26,11 +26,15 @@ function(add_clang_format_target TARGET)
   set(MULTI_VALUE_KEYWORDS OPTIONS FILES)
   cmake_parse_arguments(ARG "" "" "${MULTI_VALUE_KEYWORDS}" "${ARGN}")
 
-  find_program(CLANG_FORMAT_EXECUTABLE clang-format REQUIRED)
+  find_program(CLANG_FORMAT_EXECUTABLE clang-format)
 
-  add_custom_target(
-    ${TARGET}
-    COMMAND ${CLANG_FORMAT_EXECUTABLE} ${ARG_OPTIONS} ${ARG_FILES}
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-    COMMENT "${CLANG_FORMAT_EXECUTABLE} ${ARG_OPTIONS} ${ARG_FILES}")
+  if(CLANG_FORMAT_EXECUTABLE)
+    add_custom_target(
+      ${TARGET}
+      COMMAND ${CLANG_FORMAT_EXECUTABLE} ${ARG_OPTIONS} ${ARG_FILES}
+      WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+      COMMENT "${CLANG_FORMAT_EXECUTABLE} ${ARG_OPTIONS} ${ARG_FILES}")
+  else()
+    message(WARNING "clang-format not found, target ${TARGET} not created")
+  endif()
 endfunction()


### PR DESCRIPTION
`add_clang_format_target` does no longer fail if `clang-format` is not installed, instead it prints an error message.