### PR TITLE
feat: add `target_common_errors`

### DIFF
--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -8,4 +8,4 @@ on:
 
 jobs:
   license:
-    uses: ZIMO-Elektronik/.github-workflows/.github/workflows/license-checker.yml@v0.0.9
+    uses: ZIMO-Elektronik/.github-workflows/.github/workflows/license-checker.yml@v0.2.0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,6 +8,6 @@ on:
 
 jobs:
   tests:
-    uses: ZIMO-Elektronik/.github-workflows/.github/workflows/x86_64-linux-gnu-gcc.yml@v0.0.9
+    uses: ZIMO-Elektronik/.github-workflows/.github/workflows/x86_64-linux-gnu-gcc.yml@v0.2.0
     with:
       pre-build: sudo apt install -y libgl1-mesa-dev libglx-dev ninja-build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.10.0
+- Update to CPM 0.42.0
+- Remove errors from `target_common_warnings` and introduces `target_common_errors` instead
+
 ## 0.9.5
 - Update to CPM 0.41.0
 
@@ -21,40 +25,40 @@
 - arm-clang and arm-none-eabi-gcc toolchain files set [`CMAKE_SYSTEM_NAME`](https://cmake.org/cmake/help/latest/variable/CMAKE_SYSTEM_NAME.html) to `Generic`
 
 ## 0.8.0
-- Add build_qt
-- Add FindCQtDeployer file
+- Add `build_qt`
+- Add `FindCQtDeployer` file
 
 ## 0.7.0
-- Add add_compile_link_options
+- Add `add_compile_link_options`
 - CPM gets added implicitly
-- Change sanitize to macro
+- Change `sanitize` to macro
 
 ## 0.6.1
-- Default BUILD_TESTING=OFF
+- Default `BUILD_TESTING=OFF`
 
 ## 0.6.0
-- Add get_cqtdeployer
+- Add `get_cqtdeployer`
 
 ## 0.5.0
-- Add find_qt
+- Add `find_qt`
 
 ## 0.4.1
-- version_from_git defaults to 0.0.0 if git describe --tags errors 
+- `version_from_git` defaults to 0.0.0 if `git describe --tags` errors 
 
 ## 0.4.0
-- Add x86_64-w64-mingw32 toolchain file
+- Add `x86_64-w64-mingw32` toolchain file
 
 ## 0.3.0
-- Add add_clang_format_target
+- Add `add_clang_format_target`
 
 ## 0.2.2
 - Update to CPM 0.38.6
 
 ## 0.2.1
-- Fix target_compile_link_options
+- Fix `target_compile_link_options`
 
 ## 0.2.0
-- Fix spelling of sanitize
+- Fix spelling of `sanitize`
 
 ## 0.1.2
 - `-Werror=` argument `-Werror=implicit-function-declaration` is not valid for C++
@@ -67,23 +71,23 @@
 - Remove target_suppress_warnings (superseded by [FetchContent_Declare](https://cmake.org/cmake/help/latest/module/FetchContent.html) SYSTEM option)
 
 ## 0.0.7
-- Add METADATA to version_from_git
+- Add METADATA to `version_from_git`
 
 ## 0.0.6
-- Add version_from_git
+- Add `version_from_git`
 
 ## 0.0.5
-- Remove fetchcontent_declare_unique
+- Remove `fetchcontent_declare_unique`
 
 ## 0.0.4
-- Add gcc-12 toolchain file
+- Add `gcc-12` toolchain file
 
 ## 0.0.3
 - Add CPM
-- Add minify_html
+- Add `minify_html`
 
 ## 0.0.2
-- Add target_unity_build
+- Add `target_unity_build`
 
 ## 0.0.1
 - Initial release

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ if(NOT cpm.cmake_SOURCE_DIR)
   FetchContent_Declare(
     CPM.cmake
     GIT_REPOSITORY "https://github.com/cpm-cmake/CPM.cmake.git"
-    GIT_TAG v0.41.0)
+    GIT_TAG v0.42.0)
   FetchContent_MakeAvailable(CPM.cmake)
   include(${cpm.cmake_SOURCE_DIR}/cmake/CPM.cmake)
 endif()
@@ -26,6 +26,7 @@ include(cmake/build_qt.cmake)
 include(cmake/find_qt.cmake)
 include(cmake/minify_html.cmake)
 include(cmake/sanitize.cmake)
+include(cmake/target_common_errors.cmake)
 include(cmake/target_common_warnings.cmake)
 include(cmake/target_compile_link_options.cmake)
 include(cmake/target_unity_build.cmake)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CMakeModules
 
-[![tests](https://github.com/ZIMO-Elektronik/CMakeModules/actions/workflows/tests.yml/badge.svg)](https://github.com/ZIMO-Elektronik/CMakeModules/actions/workflows/tests.yml)
+[![tests](https://github.com/ZIMO-Elektronik/CMakeModules/actions/workflows/tests.yml/badge.svg)](https://github.com/ZIMO-Elektronik/CMakeModules/actions/workflows/tests.yml) [![license](https://img.shields.io/github/license/ZIMO-Elektronik/CMakeModules)](https://github.com/ZIMO-Elektronik/CMakeModules/raw/master/LICENSE)
 
 <img src="data/images/logo.svg" width="15%" align="right"/>
 
@@ -91,6 +91,9 @@ Add [-fsanitize](https://gcc.gnu.org/onlinedocs/gcc/Instrumentation-Options.html
 sanitize(address,undefined)
 ```
 
+### target_common_errors
+Wrapper around [target_compile_options](https://cmake.org/cmake/help/latest/command/target_compile_options.html) which adds a bunch of useful compiler errors to a target. Can also be called without any further arguments.
+
 ### target_common_warnings
 Wrapper around [target_compile_options](https://cmake.org/cmake/help/latest/command/target_compile_options.html) which adds a bunch of useful compiler warnings to a target. Can also be called without any further arguments.
 
@@ -116,9 +119,9 @@ It sets the following variables:
 - METADATA_FROM_GIT
 
 > [!IMPORTANT]
-> GitHub [actions/checkout@v4](https://github.com/actions/checkout) does not automatically checkout tags. You'll need to manually specify that, e.g.
+> GitHub [actions/checkout@v5](https://github.com/actions/checkout) does not automatically checkout tags. You'll need to manually specify that, e.g.
 > ```yml
-> - uses: actions/checkout@v4
+> - uses: actions/checkout@v5
 >   with:
 >     fetch-depth: 0
 > ```

--- a/cmake/target_common_errors.cmake
+++ b/cmake/target_common_errors.cmake
@@ -1,0 +1,55 @@
+#[[
+MIT License
+
+Copyright (c) 2025 ZIMO Elektronik
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+]]
+
+function(target_common_errors TARGET SCOPE)
+  # Common errors
+  set(COMMON_ERRORS
+      -Werror=array-bounds
+      -Werror=array-compare
+      -Werror=dangling-else
+      -Werror=implicit-fallthrough
+      -Werror=infinite-recursion
+      -Werror=logical-not-parentheses
+      -Werror=misleading-indentation
+      -Werror=null-dereference
+      -Werror=parentheses
+      -Werror=return-local-addr
+      -Werror=return-type
+      -Werror=sequence-point
+      -Werror=shift-negative-value
+      -Werror=shift-overflow
+      -Werror=sizeof-array-div
+      -Werror=strict-aliasing
+      -Werror=tautological-compare
+      -Werror=type-limits)
+
+  # C-only errors
+  set(C_ERRORS -Werror=implicit-function-declaration)
+
+  target_compile_options(${TARGET} ${SCOPE} ${COMMON_ERRORS}
+                         "$<$<COMPILE_LANGUAGE:C>:${C_ERRORS}>")
+
+  # If further arguments passed, forward
+  target_compile_options(${TARGET} ${SCOPE} ${ARGN})
+endfunction()

--- a/cmake/target_common_warnings.cmake
+++ b/cmake/target_common_warnings.cmake
@@ -23,37 +23,63 @@ SOFTWARE.
 ]]
 
 function(target_common_warnings TARGET SCOPE)
-  # Set common warnings
-  set(C_CXX_WARNINGS
-      -Wall;-Wextra;-Wshadow;-Wunused;-Wcast-align;-Wpedantic;-Wconversion;-Wsign-conversion;-Wmisleading-indentation;-Wnull-dereference;-Wdouble-promotion;-Wfatal-errors;
-  )
+  # Common warnings for both C and C++
+  set(COMMON_WARNINGS
+      -Wall
+      -Wcast-align
+      -Wcast-qual
+      -Wconversion
+      -Wdouble-promotion
+      -Wextra
+      -Wfloat-equal
+      -Wformat=2
+      -Wmisleading-indentation
+      -Wnull-dereference
+      -Wpedantic
+      -Wshadow
+      -Wsign-conversion
+      -Wundef
+      -Wunused)
+
+  # C-only warnings
+  set(C_WARNINGS -Wmissing-declarations -Wstrict-prototypes -Wvla)
+
+  # C++-only warnings
   set(CXX_WARNINGS
-      "$<$<COMPILE_LANGUAGE:CXX>:-Wnon-virtual-dtor;-Wold-style-cast;-Wsuggest-override;-Woverloaded-virtual>"
-  )
-  set(GNU_WARNINGS
-      "$<$<CXX_COMPILER_ID:GNU>:-Wduplicated-cond;-Wduplicated-branches;-Wlogical-op>"
-  )
-  set(GNU_CXX_WARNINGS "$<$<COMPILE_LANG_AND_ID:CXX,GNU>:-Wuseless-cast>")
+      -Wdelete-non-virtual-dtor
+      -Wextra-semi
+      -Wnon-virtual-dtor
+      -Wold-style-cast
+      -Woverloaded-virtual
+      -Wself-move
+      -Wsuggest-override
+      -Wzero-as-null-pointer-constant)
 
-  # Make some errors
-  set(C_ERRORS "$<$<COMPILE_LANGUAGE:C>:-Werror-implicit-function-declaration>")
-  set(C_CXX_ERRORS
-      -Werror=array-bounds;-Werror=dangling-else;-Werror=implicit-fallthrough;-Werror=parentheses;-Werror=logical-not-parentheses;-Werror=misleading-indentation;-Werror=return-type;-Werror=sequence-point;-Werror=shift-negative-value;-Werror=shift-overflow;-Werror=sizeof-array-div;-Werror=strict-aliasing;-Werror=tautological-compare;-Werror=type-limits
-  )
+  # GCC-specific warnings
+  if(CMAKE_C_COMPILER_ID MATCHES GNU)
+    list(APPEND COMMON_WARNINGS -Wduplicated-branches -Wduplicated-cond
+         -Wlogical-op)
+  endif()
+  if(CMAKE_CXX_COMPILER_ID MATCHES GNU)
+    list(APPEND CXX_WARNINGS -Wclass-memaccess -Wuseless-cast)
+  endif()
 
-  if(NOT MINGW)
-    list(APPEND C_CXX_ERRORS -Werror=array-compare;-Werror=infinite-recursion)
+  # Clang-specific warnings
+  if(CMAKE_CXX_COMPILER_ID MATCHES Clang)
+    list(
+      APPEND
+      CXX_WARNINGS
+      -Wcovered-switch-default
+      -Wextra-semi-stmt
+      -Wnewline-eof
+      -Wself-assign
+      -Wundefined-func-template)
   endif()
 
   target_compile_options(
-    ${TARGET}
-    ${SCOPE}
-    ${C_CXX_WARNINGS}
-    ${CXX_WARNINGS}
-    ${GNU_WARNINGS}
-    ${GNU_CXX_WARNINGS}
-    ${C_ERRORS}
-    ${C_CXX_ERRORS})
+    ${TARGET} ${SCOPE} ${COMMON_WARNINGS}
+    "$<$<COMPILE_LANGUAGE:C>:${C_WARNINGS}>"
+    "$<$<COMPILE_LANGUAGE:CXX>:${CXX_WARNINGS}>")
 
   # If further arguments passed, forward
   target_compile_options(${TARGET} ${SCOPE} ${ARGN})


### PR DESCRIPTION
Splits `target_common_warnings` into `*_warnings` and `*_errors`.